### PR TITLE
Fix chisel deleting a hotbar item when its GUI closes (1.20.1)

### DIFF
--- a/common/src/main/java/com/periut/chisel/gui/ChiselScreenHandler.java
+++ b/common/src/main/java/com/periut/chisel/gui/ChiselScreenHandler.java
@@ -149,7 +149,19 @@ public class ChiselScreenHandler extends ScreenHandler {
                     break; // Stop at the first chisel found
                 }
             }
-            player.getInventory().setStack(0, chiselStack);
+            // Return the chisel to the actually-held slot (selectedSlot) instead of
+            // always clobbering hotbar slot 0. Remove it from its old slot first so
+            // the same stack isn't referenced from two slots, and move the item that
+            // is currently held into the chisel's old slot so nothing is destroyed.
+            if (chiselSlot >= 0)
+            {
+                int held = player.getInventory().selectedSlot;
+                ItemStack displaced = player.getInventory().getStack(held);
+                player.getInventory().removeStack(chiselSlot);
+                player.getInventory().setStack(held, chiselStack);
+                player.getInventory().setStack(chiselSlot, displaced);
+                hand = chiselStack;
+            }
         }
         hand.getOrCreateNbt().copyFrom(InventoryUtil.createCompound(inventory));
     }


### PR DESCRIPTION
Found a bug where the chisel deletes an item from your hotbar when you close its GUI.

If you move the chisel out of your hand while the GUI is open — for example pressing a number key to swap it into your inventory when the hotbar's already full — and then close the GUI, whatever was sitting in **hotbar slot 1 just disappears**. The chisel gets shoved into that slot, overwriting the item that was there.

The cause is in `ChiselScreenHandler#onClosed`. When the chisel isn't in the main hand on close, it does:

```java
player.getInventory().setStack(0, chiselStack);
```

But slot 0 is the first hotbar slot, not your selected/held slot — so it clobbers whatever's in slot 1 regardless of what you were actually holding. On top of that, `aef116dd` dropped the `removeStack()` that used to be there, so the chisel ends up referenced in two slots at once (its old spot and slot 0).

The fix just puts the chisel back in the real held slot (`selectedSlot`) and moves the displaced item to where the chisel was, instead of nuking slot 0:

```java
if (chiselSlot >= 0) {
    int held = player.getInventory().selectedSlot;
    ItemStack displaced = player.getInventory().getStack(held);
    player.getInventory().removeStack(chiselSlot);
    player.getInventory().setStack(held, chiselStack);
    player.getInventory().setStack(chiselSlot, displaced);
    hand = chiselStack;
}
```

How to reproduce:

1. Creative mode, chisel in hand, fill all 9 hotbar slots, put something visible in slot 1.
2. Open the chisel GUI, hover over the main inventory, and press the number key of the chisel's hotbar slot (this swaps it out of the hotbar — normal clicks on the chisel are blocked, but the number-key swap isn't).
3. Close the GUI.

After: the slot 1 item is gone.

Before/after videos below (Forge 1.20.1, 47.4.20, same setup both times, only the chisel jar is different):


Before:

https://github.com/user-attachments/assets/35405f0e-f212-4dd4-917f-4daf1c6aaeac



After:

https://github.com/user-attachments/assets/3ef38eb3-3153-48de-81ce-d85477c4460d

